### PR TITLE
Story: [CCLS 2191] Use common auth starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ In order to generate the interface and models a build can be run on the overall 
 
 the caab-service implements the api interface generated in the caab-api subproject.
 This service directly interacts with the Transient Data Store in EBS.
+
+## Common Components
+
+This API uses components from the [LAA CCMS Common Library](https://github.com/ministryofjustice/laa-ccms-spring-boot-common):
+
+- [laa-ccms-spring-boot-plugin](https://github.com/ministryofjustice/laa-ccms-spring-boot-common?tab=readme-ov-file#laa-ccms-spring-boot-gradle-plugin-for-java--spring-boot-projects)
+- [laa-ccms-spring-boot-starter-auth](https://github.com/ministryofjustice/laa-ccms-spring-boot-common/tree/main/laa-ccms-spring-boot-starters/laa-ccms-spring-boot-starter-auth)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.0.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.2' apply false
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.3' apply false
 }
 
 subprojects {

--- a/caab-api/build.gradle
+++ b/caab-api/build.gradle
@@ -39,13 +39,14 @@ openApiGenerate {
     configOptions = [
             delegatePattern       : "false",
             interfaceOnly         : "true", // This will only generate interfaces, not implementations
-            dateLibrary           : "java17",
-            java17                : "true",
+            dateLibrary           : "legacy",
             useTags               : "true",
             skipDefaultInterface  : "true",
             useJakartaEe          : "true",
             documentationProvider : "none",
-            serializableModel     : "true"
+            serializableModel     : "true",
+            annotationLibrary     : "swagger2",
+            useSpringBoot3        : "true"
     ]
 }
 

--- a/caab-api/build.gradle
+++ b/caab-api/build.gradle
@@ -6,9 +6,9 @@ apply plugin: 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin'
 
 dependencies {
 
+    implementation 'io.swagger.core.v3:swagger-annotations:2.2.22'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.data:spring-data-commons'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'

--- a/caab-api/open-api-specification.yml
+++ b/caab-api/open-api-specification.yml
@@ -62,6 +62,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -91,6 +93,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -120,6 +124,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -157,6 +163,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -193,6 +201,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -222,6 +232,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -258,6 +270,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -287,6 +301,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -323,6 +339,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -352,6 +370,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -388,6 +408,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -417,6 +439,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -452,6 +476,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -483,6 +509,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -518,6 +546,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -548,6 +578,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -583,6 +615,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -614,6 +648,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -649,6 +685,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -679,6 +717,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -714,6 +754,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -745,6 +787,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -780,6 +824,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -810,6 +856,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -845,6 +893,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -876,6 +926,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -911,6 +963,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -941,6 +995,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -976,6 +1032,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1008,6 +1066,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1043,6 +1103,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1073,6 +1135,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1108,6 +1172,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1161,6 +1227,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1190,6 +1258,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1243,6 +1313,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1272,6 +1344,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1301,6 +1375,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1334,6 +1410,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1363,6 +1441,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1396,6 +1476,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1426,6 +1508,8 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
@@ -1455,12 +1539,19 @@ paths:
           description: 'Bad request'
         '401':
           description: 'Unauthorized'
+        '403':
+          description: 'Forbidden'
         '404':
           description: 'Not found'
         '500':
           description: 'Internal server error'
 
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Authorization
   schemas:
     intDisplayValue:
       type: 'object'
@@ -2501,3 +2592,6 @@ components:
           type: 'integer'
         size:
           type: 'integer'
+
+security:
+  - ApiKeyAuth: []

--- a/caab-service/build.gradle
+++ b/caab-service/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation files('lib/ojdbc8.jar')
 
     //Enable access token authentication
-    implementation 'uk.gov.laa.ccms.springboot:laa-ccms-spring-boot-starter-auth:0.0.3-b2f8726-SNAPSHOT'
+    implementation 'uk.gov.laa.ccms.springboot:laa-ccms-spring-boot-starter-auth'
 
     //Enable Swagger UI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'

--- a/caab-service/build.gradle
+++ b/caab-service/build.gradle
@@ -7,6 +7,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation files('lib/ojdbc8.jar')
 
+    //Enable access token authentication
+    implementation 'uk.gov.laa.ccms.springboot:laa-ccms-spring-boot-starter-auth:0.0.3-b2f8726-SNAPSHOT'
+
     //Enable Swagger UI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 

--- a/caab-service/build.gradle
+++ b/caab-service/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'uk.gov.laa.ccms.springboot:laa-ccms-spring-boot-starter-auth:0.0.3-b2f8726-SNAPSHOT'
 
     //Enable Swagger UI
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/caab-service/src/integrationTest/java/uk/gov/laa/ccms/data/api/IntegrationTestInterface.java
+++ b/caab-service/src/integrationTest/java/uk/gov/laa/ccms/data/api/IntegrationTestInterface.java
@@ -19,6 +19,10 @@ public interface IntegrationTestInterface {
     registry.add("spring.datasource.url", oracleContainerSingleton.getOracleContainer()::getJdbcUrl);
     registry.add("spring.datasource.username", oracleContainerSingleton.getOracleContainer()::getUsername);
     registry.add("spring.datasource.password", oracleContainerSingleton.getOracleContainer()::getPassword);
+
+    registry.add("laa.ccms.springboot.starter.auth.authorized-clients", () -> "[{\"name\":\"caab-ui\",\"roles\":[\"ALL\"],\"token\":\"c196393a-f279-45ba-b5d5-f93e6d30465a\"}]");
+    registry.add("laa.ccms.springboot.starter.auth.authorized-roles", () -> "[{\"name\":\"ALL\",\"URIs\":[\"/**\"]}]");
+    registry.add("laa.ccms.springboot.starter.auth.unprotected-uris", () -> "[\"\"]");
   }
 }
 

--- a/caab-service/src/integrationTest/java/uk/gov/laa/ccms/data/api/IntegrationTestInterface.java
+++ b/caab-service/src/integrationTest/java/uk/gov/laa/ccms/data/api/IntegrationTestInterface.java
@@ -19,10 +19,6 @@ public interface IntegrationTestInterface {
     registry.add("spring.datasource.url", oracleContainerSingleton.getOracleContainer()::getJdbcUrl);
     registry.add("spring.datasource.username", oracleContainerSingleton.getOracleContainer()::getUsername);
     registry.add("spring.datasource.password", oracleContainerSingleton.getOracleContainer()::getPassword);
-
-    registry.add("laa.ccms.springboot.starter.auth.authorized-clients", () -> "[{\"name\":\"caab-ui\",\"roles\":[\"ALL\"],\"token\":\"c196393a-f279-45ba-b5d5-f93e6d30465a\"}]");
-    registry.add("laa.ccms.springboot.starter.auth.authorized-roles", () -> "[{\"name\":\"ALL\",\"URIs\":[\"/**\"]}]");
-    registry.add("laa.ccms.springboot.starter.auth.unprotected-uris", () -> "[\"\"]");
   }
 }
 

--- a/caab-service/src/integrationTest/resources/application-local.yml
+++ b/caab-service/src/integrationTest/resources/application-local.yml
@@ -9,24 +9,3 @@ spring:
     database-platform: org.hibernate.dialect.OracleDialect
     hibernate:
       ddl-auto: none
-
-laa.ccms.springboot.starter.auth:
-  authentication-header: "Authorization"
-  authorized-clients: '[
-      {
-          "name": "integration-test-runner",
-          "roles": [
-              "ALL"
-          ],
-          "token": "c196393a-f279-45ba-b5d5-f93e6d30465a"
-      }
-  ]'
-  authorized-roles: '[
-      {
-          "name": "ALL",
-          "URIs": [
-              "/**"
-          ]
-      }
-  ]'
-  unprotected-uris: [ "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico", "/open-api-specification.yml"]

--- a/caab-service/src/integrationTest/resources/application-local.yml
+++ b/caab-service/src/integrationTest/resources/application-local.yml
@@ -9,3 +9,24 @@ spring:
     database-platform: org.hibernate.dialect.OracleDialect
     hibernate:
       ddl-auto: none
+
+laa.ccms.springboot.starter.auth:
+  authentication-header: "Authorization"
+  authorized-clients: '[
+      {
+          "name": "integration-test-runner",
+          "roles": [
+              "ALL"
+          ],
+          "token": "c196393a-f279-45ba-b5d5-f93e6d30465a"
+      }
+  ]'
+  authorized-roles: '[
+      {
+          "name": "ALL",
+          "URIs": [
+              "/**"
+          ]
+      }
+  ]'
+  unprotected-uris: [ "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico", "/open-api-specification.yml"]

--- a/caab-service/src/integrationTest/resources/application.yml
+++ b/caab-service/src/integrationTest/resources/application.yml
@@ -1,0 +1,31 @@
+laa:
+  ccms:
+    caab:
+      converters:
+        boolean:
+          true_values:
+            Y,Yes
+          false_values:
+            N,No
+    springboot:
+      starter:
+        auth:
+          authentication-header: "Authorization"
+          authorized-clients: '[
+              {
+                  "name": "integration-test-runner",
+                  "roles": [
+                      "ALL"
+                  ],
+                  "token": "c196393a-f279-45ba-b5d5-f93e6d30465a"
+              }
+          ]'
+          authorized-roles: '[
+              {
+                  "name": "ALL",
+                  "URIs": [
+                      "/**"
+                  ]
+              }
+          ]'
+          unprotected-uris: [ "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico", "/open-api-specification.yml"]

--- a/caab-service/src/main/resources/application-local.yml
+++ b/caab-service/src/main/resources/application-local.yml
@@ -12,3 +12,24 @@ spring:
 
 server:
   port: 8005
+
+laa.ccms.springboot.starter.auth:
+  authentication-header: "Authorization"
+  authorized-clients: '[
+      {
+          "name": "caab-ui",
+          "roles": [
+              "ALL"
+          ],
+          "token": "c196393a-f279-45ba-b5d5-f93e6d30465a"
+      }
+  ]'
+  authorized-roles: '[
+      {
+          "name": "ALL",
+          "URIs": [
+              "/**"
+          ]
+      }
+  ]'
+  unprotected-uris: [ "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico", "/open-api-specification.yml"]

--- a/caab-service/src/main/resources/application.yml
+++ b/caab-service/src/main/resources/application.yml
@@ -20,3 +20,9 @@ laa:
             Y,Yes
           false_values:
             N,No
+
+laa.ccms.springboot.starter.auth:
+  authentication-header: "Authorization"
+  authorized-clients: ${AUTHORIZED_CLIENTS}
+  authorized-roles: ${AUTHORIZED_ROLES}
+  unprotected-uris: ${UNPROTECTED_URIS}


### PR DESCRIPTION
* Use [common auth starter](https://github.com/ministryofjustice/laa-ccms-spring-boot-common/pull/4)
  * Added application properties to configure auth
* Added 403 Forbidden to endpoints in OpenAPI spec
* Added configuration to handle authentication during testing

**DRAFT**: Common library version needs to be removed (to use version provided by SB plugin) when Auth Starter PR is merged.