### PR TITLE
[FIX] Update upload artifact action

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -73,7 +73,7 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: upload jarfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: caab-api-jar
           path: caab-service/build/libs/caab-service-${{ steps.capture_version.outputs.app_version }}.jar


### PR DESCRIPTION
Should fix the incompatibility with artifact download version update from https://github.com/ministryofjustice/laa-ccms-caab-api/pull/49.