### PR TITLE
Update dependabot, bump versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,30 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+registries:
+  spring-boot-common-github-packages:
+    type: maven-repository
+    url: https://maven.pkg.github.com/ministryofjustice/laa-ccms-spring-boot-common
+    username: PhilDigitalJustice
+    password: ${{ secrets.REPO_TOKEN }}
 updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    registries: "*"
     groups:
       gradle-updates:
         patterns:
-          - "**" # Matches all Gradle dependencies
+          - "!uk.gov.laa.ccms.*" # All external Gradle dependencies
+      internal-packages:
+        patterns:
+          - "uk.gov.laa.ccms.*" # All internal Gradle dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "**"

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -44,15 +44,13 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Build with Gradle
-        run: ./gradlew build -Pversion=${{ steps.capture_version.outputs.app_version }}
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test coverage verification
-        run: ./gradlew jacocoTestCoverageVerification
-
-      - name: Integration Test
+      - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
 
       - name: Publish package

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -64,6 +64,20 @@ jobs:
           name: caab-api-jar
           path: caab-service/build/libs/caab-service-${{ steps.capture_version.outputs.app_version }}.jar
 
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: caab-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: caab-service/build/reports/jacoco
+          retention-days: 14
+
   ecr:
     needs: [ build-test-publish, define-image-tag ]
     runs-on: ubuntu-latest

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -42,27 +42,21 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build -Pversion=${{ steps.capture_version.outputs.app_version }}
+        run: ./gradlew build -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest --tests '*IntegrationTest'
+        run: ./gradlew integrationTest --tests '*IntegrationTest'
 
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish -Pversion=${{ steps.capture_version.outputs.app_version }}
+        run: ./gradlew publish -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -46,9 +46,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification -Pversion=${{ steps.capture_version.outputs.app_version }}
+        run: ./gradlew build -Pversion=${{ steps.capture_version.outputs.app_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
@@ -64,7 +67,16 @@ jobs:
           name: caab-api-jar
           path: caab-service/build/libs/caab-service-${{ steps.capture_version.outputs.app_version }}.jar
 
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: caab-service/build/reports/checkstyle
+          retention-days: 14
+
       - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report
@@ -72,6 +84,7 @@ jobs:
           retention-days: 14
 
       - name: Upload jacoco coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-coverage-report

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -40,10 +40,10 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: assemble
+        run: ./gradlew assemble
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -56,9 +56,7 @@ jobs:
           echo "Captured version: $VERSION"
 
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -42,7 +42,8 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Build with Gradle
+
+      - name: Build
         run: ./gradlew assemble
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -69,6 +69,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
       SNYK_TEST_EXCLUDE: build,generated
+      SNYK_TARGET_REFERENCE: main
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -78,12 +79,12 @@ jobs:
         continue-on-error: true
         with:
           command: monitor
-          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE
+          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE
       - name: Generate sarif Snyk report
         uses: snyk/actions/gradle@0.4.0
         continue-on-error: true
         with:
-          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE --sarif-file-output=snyk-report.sarif
+          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE --sarif-file-output=snyk-report.sarif
       - name: Fix undefined values
         run: |
           cat snyk-report.sarif | jq '

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -50,6 +50,20 @@ jobs:
       - name: Update version
         run: ./gradlew release -Prelease.useAutomaticVersion=true
 
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: caab-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: caab-service/build/reports/jacoco
+          retention-days: 14
+
   vulnerability-report:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -31,22 +31,18 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest --tests '*IntegrationTest'
+        run: ./gradlew integrationTest --tests '*IntegrationTest'
 
       - name: Set to github user
         run: |
@@ -54,9 +50,7 @@ jobs:
           git config --global user.name "GitHub Actions Bot"
 
       - name: Update version
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: release -Prelease.useAutomaticVersion=true
+        run: ./gradlew release -Prelease.useAutomaticVersion=true
 
   vulnerability-report:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -35,9 +35,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
@@ -50,7 +53,16 @@ jobs:
       - name: Update version
         run: ./gradlew release -Prelease.useAutomaticVersion=true
 
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: caab-service/build/reports/checkstyle
+          retention-days: 14
+
       - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report
@@ -58,6 +70,7 @@ jobs:
           retention-days: 14
 
       - name: Upload jacoco coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-coverage-report

--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -33,15 +33,13 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Build with Gradle
-        run: ./gradlew build
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test coverage verification
-        run: ./gradlew jacocoTestCoverageVerification
-
-      - name: Integration Test
+      - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
 
       - name: Set to github user

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -32,9 +32,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build & test
-        run: ./gradlew build jacocoTestCoverageVerification
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'
@@ -47,7 +50,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload checkstyle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: caab-service/build/reports/checkstyle
+          retention-days: 14
+
       - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report
@@ -55,6 +67,7 @@ jobs:
           retention-days: 14
 
       - name: Upload jacoco coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-coverage-report

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -63,6 +63,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       SNYK_ORG: legal-aid-agency
       SNYK_TEST_EXCLUDE: build,generated
+      SNYK_TARGET_REFERENCE: main
 
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +80,7 @@ jobs:
           export PATH="$HOME/.local/bin/:$PATH"
           npm install -g snyk-delta
       - name: Identify new vulnerabilities
-        run: ./snyk/snyk_delta_all_projects.sh --org=$SNYK_ORG --exclude=$SNYK_TEST_EXCLUDE
+        run: ./snyk/snyk_delta_all_projects.sh --org=$SNYK_ORG --exclude=$SNYK_TEST_EXCLUDE --target-reference=$SNYK_TARGET_REFERENCE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run code test

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -47,6 +47,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: caab-service/build/reports/tests
+          retention-days: 14
+
+      - name: Upload jacoco coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-report
+          path: caab-service/build/reports/jacoco
+          retention-days: 14
+
   vulnerability-scan:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -30,13 +30,11 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Build with Gradle
-        run: ./gradlew build
+
+      - name: Build & test
+        run: ./gradlew build jacocoTestCoverageVerification
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Test coverage verification
-        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Integration test
         run: ./gradlew integrationTest --tests '*IntegrationTest'

--- a/.github/workflows/push-branch.yml
+++ b/.github/workflows/push-branch.yml
@@ -28,31 +28,24 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: build
+        run: ./gradlew build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: jacocoTestCoverageVerification
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
-      - name: Integration Test
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: integrationTest --tests '*IntegrationTest'
+      - name: Integration test
+        run: ./gradlew integrationTest --tests '*IntegrationTest'
 
       - name: Update snapshot version
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: updateSnapshotVersion
+        run: ./gradlew updateSnapshotVersion
+
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Please ensure this matches the command used by the [pr-merge-main](.github/workf
 workflow to maintain consistency.
 
 ```shell
-snyk monitor --org=legal-aid-agency --all-projects --exclude=build,generated
+snyk monitor --org=legal-aid-agency --all-projects --exclude=build,generated --target-reference=main
 ```
 
 You should then see the new vulnerability in the LAA Dashboard, otherwise it is a new

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.0.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.8' apply false
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.24' apply false
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '3.0.2'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.24' apply false
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.25' apply false
 }
 
 subprojects {

--- a/caab-service/build.gradle
+++ b/caab-service/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
 test {
     useJUnitPlatform()
+
+    finalizedBy jacocoTestReport
 }
 
 jacocoTestReport {

--- a/caab-service/build.gradle
+++ b/caab-service/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 
     //Used for integration tests
-    implementation platform('org.testcontainers:testcontainers-bom:1.19.3')
+    testImplementation platform('org.testcontainers:testcontainers-bom:1.20.4')
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:oracle-free'

--- a/caab-service/src/main/java/uk/gov/laa/ccms/caab/api/entity/Application.java
+++ b/caab-service/src/main/java/uk/gov/laa/ccms/caab/api/entity/Application.java
@@ -95,6 +95,7 @@ public class Application implements Serializable {
   private String relationToLinkedCase;
 
   @Column(name = "OPPONENT_APPLIED_FOR_FUNDING")
+  @Convert(converter = NumericBooleanConverter.class)
   private Boolean opponentAppliedForFunding;
 
   //status

--- a/caab-service/src/main/java/uk/gov/laa/ccms/caab/api/entity/Application.java
+++ b/caab-service/src/main/java/uk/gov/laa/ccms/caab/api/entity/Application.java
@@ -94,8 +94,8 @@ public class Application implements Serializable {
   @Column(name = "RELATION_TO_LINKED_CASE", length = 50)
   private String relationToLinkedCase;
 
-  @Column(name = "OPPONENT_APPLIED_FOR_FUNDING")
   @Convert(converter = NumericBooleanConverter.class)
+  @Column(name = "OPPONENT_APPLIED_FOR_FUNDING")
   private Boolean opponentAppliedForFunding;
 
   //status

--- a/caab-service/src/main/java/uk/gov/laa/ccms/caab/api/entity/Opponent.java
+++ b/caab-service/src/main/java/uk/gov/laa/ccms/caab/api/entity/Opponent.java
@@ -301,6 +301,7 @@ public class Opponent implements Serializable {
   /**
    * Indicates if the Opponent is marked for deletion.
    */
+  @Convert(converter = NumericBooleanConverter.class)
   @Column(name = "DELETE_IND")
   private Boolean deleteInd;
 


### PR DESCRIPTION
* Dependabot
  * Scan for github-actions updates
  * Scan for SB common library updates
* Snyk
  * Consolidate reporting - duplicate reports are created when running `monitor` from local cli vs in the pipeline. Adding `--target-reference=main` to all commands should make them point to one report. 
* Bump to latest SB common library version
  * Fixed bug where boolean entity properties were rejected by Oracle using the latest version of JPA. The properties were missing boolean converters and Boolean is not a valid type in oracle.
  * Fixed bug where duplicate unit tests would run twice in pipelines (`build` would run tests, followed by `jacocoTestVerification`)
* Workflows
  * Replace deprecated `gradle-build-action` with `setup-gradle` action
  * Upload checkstyle, test and jacoco coverage artifacts
  * Fixed bug where test coverage verification would run without jacoco report (effectively always passing)